### PR TITLE
gradle 7 compatibility

### DIFF
--- a/src/main/java/nl/martijndwars/markdown/CompileHtmlToPdfTask.java
+++ b/src/main/java/nl/martijndwars/markdown/CompileHtmlToPdfTask.java
@@ -1,8 +1,8 @@
 package nl.martijndwars.markdown;
 
 import com.itextpdf.text.DocumentException;
+import org.gradle.api.DefaultTask;
 import org.gradle.api.file.RegularFileProperty;
-import org.gradle.api.internal.AbstractTask;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
@@ -12,7 +12,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 
-public class CompileHtmlToPdfTask extends AbstractTask {
+public class CompileHtmlToPdfTask extends DefaultTask {
     protected final RegularFileProperty inputFile;
     protected final RegularFileProperty outputFile;
 

--- a/src/main/java/nl/martijndwars/markdown/CompileMarkdownToHtmlTask.java
+++ b/src/main/java/nl/martijndwars/markdown/CompileMarkdownToHtmlTask.java
@@ -5,8 +5,8 @@ import org.commonmark.ext.gfm.tables.TablesExtension;
 import org.commonmark.node.Node;
 import org.commonmark.parser.Parser;
 import org.commonmark.renderer.html.HtmlRenderer;
+import org.gradle.api.DefaultTask;
 import org.gradle.api.file.RegularFileProperty;
-import org.gradle.api.internal.AbstractTask;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
@@ -18,7 +18,7 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 
-public class CompileMarkdownToHtmlTask extends AbstractTask {
+public class CompileMarkdownToHtmlTask extends DefaultTask {
     protected final RegularFileProperty inputFile;
     protected final RegularFileProperty outputFile;
 

--- a/src/main/java/nl/martijndwars/markdown/CompileMarkdownToHtmlTask.java
+++ b/src/main/java/nl/martijndwars/markdown/CompileMarkdownToHtmlTask.java
@@ -8,6 +8,7 @@ import org.commonmark.renderer.html.HtmlRenderer;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
 import org.jsoup.Jsoup;
@@ -44,6 +45,7 @@ public class CompileMarkdownToHtmlTask extends DefaultTask {
         writeOutput(output);
     }
 
+    @Internal
     protected String getInputString() throws IOException {
         Path inputPath = inputFile.get().getAsFile().toPath();
 
@@ -63,18 +65,21 @@ public class CompileMarkdownToHtmlTask extends DefaultTask {
         Files.write(outputPath, output.getBytes());
     }
 
+    @Internal
     protected Parser getOrCreateParser() {
         return Parser.builder()
                 .extensions(getCommonMarkExtensions())
                 .build();
     }
 
+    @Internal
     protected HtmlRenderer getOrCreateHtmlRenderer() {
         return HtmlRenderer.builder()
                 .extensions(getCommonMarkExtensions())
                 .build();
     }
 
+    @Internal
     protected List<Extension> getCommonMarkExtensions() {
         return Arrays.asList(TablesExtension.create());
     }

--- a/src/main/java/nl/martijndwars/markdown/CompileMarkdownToPdf.java
+++ b/src/main/java/nl/martijndwars/markdown/CompileMarkdownToPdf.java
@@ -1,8 +1,8 @@
 package nl.martijndwars.markdown;
 
+import org.gradle.api.DefaultTask;
 import org.gradle.api.Project;
 import org.gradle.api.file.RegularFileProperty;
-import org.gradle.api.internal.AbstractTask;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
@@ -12,7 +12,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 
-public class CompileMarkdownToPdf extends AbstractTask {
+public class CompileMarkdownToPdf extends DefaultTask {
     protected final RegularFileProperty inputFile;
     protected final RegularFileProperty outputFile;
 

--- a/src/main/java/nl/martijndwars/markdown/CompileMarkdownToPdf.java
+++ b/src/main/java/nl/martijndwars/markdown/CompileMarkdownToPdf.java
@@ -4,6 +4,7 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.Project;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.TaskContainer;
@@ -33,6 +34,7 @@ public class CompileMarkdownToPdf extends DefaultTask {
         dependsOn(compileHtmlToPdfTask);
     }
 
+    @Internal
     protected File getTemporaryFile() throws IOException {
         Path temporaryDir = getTemporaryDir().toPath();
         Path temporaryFile = temporaryDir.resolve("temporaryFile.html");


### PR DESCRIPTION
Fixes two issues triggering warnings on gradle 6.7 about compatibility with gradle 7.

Extend DefaultTask instead of AbstractTask:
https://docs.gradle.org/6.7/userguide/upgrading_version_6.html#abstract_task_deprecated

Annotate internal getters:
https://docs.gradle.org/current/userguide/validation_problems.html#missing_annotation
